### PR TITLE
Error Handling

### DIFF
--- a/examples/saml-client.js
+++ b/examples/saml-client.js
@@ -27,7 +27,10 @@ authOptions['password'] = process.argv[3];
 authOptions['host'] = config.host || 's6hanaxs.hanatrial.ondemand.com';
 authOptions['path'] = '/p598692trial/helloworld/sample/services/samples.xsodata/Samples';
 
-var cookieHana = hanaSaml.authenticate(authOptions, function(cookie){
+var cookieHana = hanaSaml.authenticate(authOptions, function(error, cookie){
+  if (error) {
+    return console.error(error);
+  }
   // console.log('saml-client cookieHana: ' + cookie);
 
   headers = {

--- a/examples/server-basic-auth.js
+++ b/examples/server-basic-auth.js
@@ -116,7 +116,10 @@ var proxy = function (req, res) {
     if(sessionCache[authData.hash] === undefined 
        || sessionCache[authData.hash].timestamp <= timestampTimeout){
       console.log('Get new session cookie');
-      hanaSaml.authenticate(samlAuthData, function(cookie){
+      hanaSaml.authenticate(samlAuthData, function(error, cookie){
+        if (error) {
+          return console.error(error);
+        }
         // console.log(cookie);
         if(cookie === undefined){
           res.end('Authentication failed.');

--- a/lib/hana-saml.js
+++ b/lib/hana-saml.js
@@ -114,7 +114,7 @@ module.exports.authenticate = function (authOptions, callback) {
         if(messages != '') {
           // console.log(messages);
           cookieHana = undefined;
-          callback(cookieHana);
+          callback(null, cookieHana);
         } else {
           // Read the Form Action + Method
           action = $('form').attr('action');

--- a/lib/hana-saml.js
+++ b/lib/hana-saml.js
@@ -2,6 +2,25 @@
 
 module.exports.authenticate = function (authOptions, callback) {
 
+  // In the first version of this module,
+  // the callback function only took one parameter
+  // which was the cookie. However, the first parameter 
+  // should always be a potential error.
+  // To remain backwards-compatible, we check for the number
+  // of arguments of the callback and if there's only one,
+  // then it's probably still the old syntax and we just wrap it
+  if (callback.length === 1) {
+    // callback has only 1 argument, wrap it
+    var origCallback = callback;
+    callback = function(error, cookie) {
+      if (error) {
+        throw error
+      } else {
+        origCallback(cookie);
+      }
+    }
+  }
+
   function createOptions(authOptions, url) {
     var options;  
     if(authOptions.proxy) {
@@ -33,12 +52,19 @@ module.exports.authenticate = function (authOptions, callback) {
   // Request the XSOData Service
   // console.log(options);
   var req = request.get(options, function (error, res, resbody) {
+    if (error) {
+      return callback(error);
+    } else if (res.statusCode >= 400) {
+      return callback('Something went wrong: ' + url + ' returned ' + res.statusCode);
+    }
     // console.log(res);
     var cookieHana = res.headers['set-cookie'];
     var location = res.headers.location;
-    // console.log(location);
     var options = createOptions(authOptions, location);
     var req2 = request.get(options, function (error, res, resbody) {
+      if (error) {
+        return callback(error);
+      }
       var cookieAccounts = res.headers['set-cookie'];
       $ = cheerio.load(resbody);
       // Read the Form Action + Method
@@ -74,6 +100,9 @@ module.exports.authenticate = function (authOptions, callback) {
       // console.log(options);
       // Set up the request
       var post_req = request.post(options, function (error, res, resbody) {
+        if (error) {
+          return callback(error);
+        }
         cookieAccounts = res.headers['set-cookie'];
         // console.log(cookieAccounts);
         // console.log(res);
@@ -105,25 +134,32 @@ module.exports.authenticate = function (authOptions, callback) {
           options.headers = headers;        
           // console.log(options);        
           var post_req2 = request.post(options, function (error, res, resbody) {
+            if (error) {
+              return callback(error);
+            }
             // console.log(res);
             cookieHana = res.headers['set-cookie'];
             // console.log(cookieHana);
-            callback(cookieHana);
+            callback(null, cookieHana);
           });
           post_req2.on('error', function(e) {
             console.log('problem with request: ' + e.message);
+            callback(e);
           });
         }
       });
       post_req.on('error', function(e) {
         console.log('problem with request: ' + e.message);
+        callback(e);
       });
     });
     req2.on('error', function(e) {
       console.log('problem with request: ' + e.message);
+      callback(e);
     });
   });
   req.on('error', function(e) {
     console.log('problem with request: ' + e.message);
+    callback(e);
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hanatrial-auth-proxy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SAP HANA Cloud Authentication Proxy for HANA XS",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds error handling to the `authenticate()` function. The callback that is passed to the API receives an optional error as the first argument. The second argument is the cookie that was received. The lib code base and the examples have been adjusted.

The change is still backward-compatible. If a callback is passed that only takes one parameter (i.e. the cookie), then the callback will be called with the cookie and no error.

Max
